### PR TITLE
Added multiple ways to construct a PidController

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/motions/PidController.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/motions/PidController.java
@@ -1,18 +1,68 @@
 package org.firstinspires.ftc.teamcode.motions;
 
+import androidx.annotation.NonNull;
+
 public class PidController {
 
     private final double kp;
     private final double kd;
 
+    /**
+     * Construct a {@code PidController} object from the given kp and kd values
+     *
+     * @param kp The kp value to be set
+     * @param kd The kd value to be set
+     */
     public PidController(double kp, double kd) {
         this.kp = kp;
         this.kd = kd;
     }
 
+    /**
+     * Construct a {@code PidController} object from a
+     * {@link PidControllerParameters}
+     *
+     * @param values The given enum
+     */
+    public PidController(@NonNull PidControllerParameters values) {
+        this.kp = values.getKp();
+        this.kd = values.getKd();
+    }
+
+    /**
+     * Builder for the {@code PidController} class that follows the builder pattern
+     */
+    public static class Builder {
+        private double kp;
+        private double kd;
+
+        public Builder withKp(double kp) {
+            this.kp = kp;
+            return this;
+        }
+
+        public Builder withKd(double kd) {
+            this.kd = kd;
+            return this;
+        }
+
+        public PidController build() {
+            if (kp == 0 && kd == 0) {
+                throw new IllegalStateException("Missing either withKp or withKd");
+            }
+            return new PidController(kp, kd);
+        }
+    }
+
+    /**
+     * Calculate the power with the kp and kd values set in the object
+     *
+     * @param error the error to be used in the calculation
+     * @param time  the amount of time to be used in the calculation
+     * @return the calculated power with the given error and time
+     */
     public double calculatePower(double error, long time) {
         // TODO: use kd
         return kp * error + kd * 0;
-
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/motions/PidControllerParameters.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/motions/PidControllerParameters.java
@@ -1,0 +1,25 @@
+package org.firstinspires.ftc.teamcode.motions;
+
+
+/**
+ * The enum that is used to create a {@link PidController} with preset values
+ */
+public enum PidControllerParameters {
+    TURNING(0.03,0);
+
+    private final double kp;
+    private final double kd;
+
+    PidControllerParameters(double kp, double kd) {
+        this.kp = kp;
+        this.kd = kd;
+    }
+
+    public double getKp() {
+        return kp;
+    }
+
+    public double getKd() {
+        return kd;
+    }
+}

--- a/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/motions/PidControllerTest.java
+++ b/TeamCode/src/test/java/org/firstinspires/ftc/teamcode/motions/PidControllerTest.java
@@ -1,0 +1,22 @@
+package org.firstinspires.ftc.teamcode.motions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class PidControllerTest {
+    @Test
+    void makeWithEnum() {
+        PidController controller = new PidController(PidControllerParameters.TURNING);
+        assertEquals(5 * 0.03, controller.calculatePower(5, 0));
+    }
+
+    @Test
+    void makeWithBuilder() {
+        PidController controller = new PidController.Builder()
+                .withKp(0.03)
+                .withKd(0)
+                .build();
+        assertEquals(5 * 0.03, controller.calculatePower(5, 0));
+    }
+}


### PR DESCRIPTION
Added multiple ways to construct a `PidController`:

- Construct with a given `PidControllerParameters` enum value. The enum value  encapsulates the kp and kd values used in the `PidController`.
- Construct with the builder pattern. Introduced a Builder inner class  in the `PidController` class.